### PR TITLE
[5.0.x] add firefox version at .travis.yml #85

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ sudo: false
 language: java
 jdk:
   - oraclejdk7
+addons:
+  firefox: "38.8.0esr"
 cache:
   directories:
     - $HOME/.m2


### PR DESCRIPTION
(cherry picked from commit d39437b9a36faccc8385c003977bb05c55b0a52b)

Conflicts:
	.travis.yml

Above Conflict happen because 5.0.x use different jdk version from master .

Please review #85 .
This PR is backport for 5.0.x .
