### PR TITLE
fix bug that web browser does not close at the end of the test #183

### DIFF
--- a/common/src/test/java/org/terasoluna/gfw/tutorial/selenium/FunctionTestSupport.java
+++ b/common/src/test/java/org/terasoluna/gfw/tutorial/selenium/FunctionTestSupport.java
@@ -193,6 +193,7 @@ public class FunctionTestSupport extends ApplicationObjectSupport {
             driver = new FirefoxDriver(profile);
         }
 
+        webDrivers.add(driver);
         return driver;
     }
 


### PR DESCRIPTION
Please review #183 .

I made the "[tearDownWebDrivers](https://github.com/terasolunaorg/tutorial-apps/blob/d07ce31bd3d649d7a7e39c25204798c08faf745e/common/src/test/java/org/terasoluna/gfw/tutorial/selenium/FunctionTestSupport.java#L120)" method work properly after testing