### PR TITLE
[1.0.x] reflect guideline change #172

### DIFF
--- a/todo/src/main/webapp/WEB-INF/views/todo/list.jsp
+++ b/todo/src/main/webapp/WEB-INF/views/todo/list.jsp
@@ -9,6 +9,10 @@
     text-decoration: line-through;
 }
 
+.inline {
+    display: inline-block;
+}
+
 .alert {
     border: 1px solid;
 }
@@ -57,7 +61,7 @@
                                 action="${pageContext.request.contextPath}/todo/finish"
                                 method="post"
                                 modelAttribute="todoForm"
-                                cssStyle="display: inline-block;">
+                                cssClass="inline">
                                 <form:hidden path="todoId"
                                     value="${f:h(todo.todoId)}" />
                                 <input type="submit" name="finish"
@@ -68,7 +72,7 @@
                     <form:form
                         action="${pageContext.request.contextPath}/todo/delete"
                         method="post" modelAttribute="todoForm"
-                        cssStyle="display: inline-block;">
+                        cssClass="inline">
                         <form:hidden path="todoId"
                             value="${f:h(todo.todoId)}" />
                         <input type="submit" value="Delete" />


### PR DESCRIPTION
(cherry picked from commit b30b32d7a1127fc2cf58ebf7f01bfa4a49333561)

Conflicts:
	common/scripts/convert-common-css.sh

Please review #172 .

This PR is backport for 1.0.x .

In 1.0.x, css files do not used, but since the style tag is written, it was modified to be defined with the style tag.